### PR TITLE
Fall back on platform.machine() to determine the platform architecture.

### DIFF
--- a/frontend/tests/unit/test_source_generator.py
+++ b/frontend/tests/unit/test_source_generator.py
@@ -95,6 +95,9 @@ def test_branch_implicit_fallthrough(resources, tmpdir):
 
 def switch_processor(value1, value2):
     processor = platform.processor()
+    if not processor:
+      # platform.processor() is not always populated.
+      processor = platform.machine()
     if processor == 'x86_64':
         return value1
     elif processor == 'aarch64':


### PR DESCRIPTION
platform.processor() is often not populated on many platforms.

Tested this on my workstation (which previously failed due to an empty processor string).