### PR TITLE
Use $(CC) instead of gcc in generated makefiles.

### DIFF
--- a/frontend/src/frontend/code_generator/source_generator.py
+++ b/frontend/src/frontend/code_generator/source_generator.py
@@ -146,10 +146,11 @@ class SourceGenerator:
             string = (
                 f'{prefetch_ifdef}'
                 f'{self.benchmark_name}: {obj_files}\n'
-                f'\tgcc -o {self.benchmark_name} {obj_files} {cflags_str}\n\n')
+                f'\t$(CC) -o {self.benchmark_name} {obj_files} {cflags_str}\n'
+                '\n')
             for obj_file, c_file in dependencies.items():
                 string += f'{obj_file}: {c_file}\n'
-                string += f'\tgcc -c -o {obj_file} {c_file} {cflags_str}\n\n'
+                string += f'\t$(CC) -c -o {obj_file} {c_file} {cflags_str}\n\n'
             string += f'clean:\n\trm *.o {self.benchmark_name}\n'
             f.write(string)
 

--- a/frontend/tests/resources/write_onecallchain/Makefile
+++ b/frontend/tests/resources/write_onecallchain/Makefile
@@ -3,13 +3,13 @@ ifdef ENABLE_PREFETCH
 endif
 
 benchmark: 0.o main.o
-	gcc -o benchmark 0.o main.o $(DENABLE_PREFETCH) -O0
+	$(CC) -o benchmark 0.o main.o $(DENABLE_PREFETCH) -O0
 
 0.o: 0.c
-	gcc -c -o 0.o 0.c $(DENABLE_PREFETCH) -O0
+	$(CC) -c -o 0.o 0.c $(DENABLE_PREFETCH) -O0
 
 main.o: main.c
-	gcc -c -o main.o main.c $(DENABLE_PREFETCH) -O0
+	$(CC) -c -o main.o main.c $(DENABLE_PREFETCH) -O0
 
 clean:
 	rm *.o benchmark

--- a/frontend/tests/resources/write_onefunction/Makefile
+++ b/frontend/tests/resources/write_onefunction/Makefile
@@ -3,13 +3,13 @@ ifdef ENABLE_PREFETCH
 endif
 
 benchmark: 0.o main.o
-	gcc -o benchmark 0.o main.o $(DENABLE_PREFETCH) -O0
+	$(CC) -o benchmark 0.o main.o $(DENABLE_PREFETCH) -O0
 
 0.o: 0.c
-	gcc -c -o 0.o 0.c $(DENABLE_PREFETCH) -O0
+	$(CC) -c -o 0.o 0.c $(DENABLE_PREFETCH) -O0
 
 main.o: main.c
-	gcc -c -o main.o main.c $(DENABLE_PREFETCH) -O0
+	$(CC) -c -o main.o main.c $(DENABLE_PREFETCH) -O0
 
 clean:
 	rm *.o benchmark

--- a/frontend/tests/resources/write_onefunction_globalvars/Makefile
+++ b/frontend/tests/resources/write_onefunction_globalvars/Makefile
@@ -3,13 +3,13 @@ ifdef ENABLE_PREFETCH
 endif
 
 benchmark: 0.o main.o
-	gcc -o benchmark 0.o main.o $(DENABLE_PREFETCH) -O0
+	$(CC) -o benchmark 0.o main.o $(DENABLE_PREFETCH) -O0
 
 0.o: 0.c
-	gcc -c -o 0.o 0.c $(DENABLE_PREFETCH) -O0
+	$(CC) -c -o 0.o 0.c $(DENABLE_PREFETCH) -O0
 
 main.o: main.c
-	gcc -c -o main.o main.c $(DENABLE_PREFETCH) -O0
+	$(CC) -c -o main.o main.c $(DENABLE_PREFETCH) -O0
 
 clean:
 	rm *.o benchmark


### PR DESCRIPTION
Helps with cross compiling generated benchmarks.